### PR TITLE
[member-service] feat: internal API for coupon ussage during order and defining custom exceptions

### DIFF
--- a/module-common/src/main/java/com/github/msafriends/modulecommon/dto/ErrorResponse.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/dto/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.github.msafriends.modulecommon.dto;
 
+import lombok.Builder;
 import org.springframework.http.HttpStatus;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,13 +18,26 @@ public class ErrorResponse {
 	@JsonIgnore
 	private HttpStatus status;
 
-	private ErrorResponse(ErrorCode errorCode) {
-		this.status = errorCode.getStatus();
-		this.code = errorCode.getCode();
-		this.message = errorCode.getMessage();
+	@Builder
+	private ErrorResponse(HttpStatus status,String code, String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode){
-		return new ErrorResponse(errorCode);
+		return ErrorResponse.builder()
+				.status(errorCode.getStatus())
+				.code(errorCode.getCode())
+				.message(errorCode.getMessage())
+				.build();
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, String message) {
+		return ErrorResponse.builder()
+				.status(errorCode.getStatus())
+				.code(errorCode.getCode())
+				.message(message)
+				.build();
 	}
 }

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/dto/ErrorResponse.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/dto/ErrorResponse.java
@@ -10,19 +10,24 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+import java.util.Map;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 	private String message;
 	private String code;
+	private List<FieldError> fieldErrors;
 	@JsonIgnore
 	private HttpStatus status;
 
 	@Builder
-	private ErrorResponse(HttpStatus status,String code, String message) {
+	private ErrorResponse(HttpStatus status,String code, String message, List<FieldError> fieldErrors) {
 		this.status = status;
 		this.code = code;
 		this.message = message;
+		this.fieldErrors = fieldErrors;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode){
@@ -39,5 +44,28 @@ public class ErrorResponse {
 				.code(errorCode.getCode())
 				.message(message)
 				.build();
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, Map<String, String> fieldErrors) {
+		List<FieldError> errors = fieldErrors.entrySet().stream()
+				.map(entry -> new FieldError(entry.getKey(), entry.getValue())).toList();
+
+		return ErrorResponse.builder()
+				.status(errorCode.getStatus())
+				.code(errorCode.getCode())
+				.fieldErrors(errors)
+				.build();
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	protected static class FieldError {
+		private String field;
+		private String message;
+
+		public FieldError(String field, String message) {
+			this.field = field;
+			this.message = message;
+		}
 	}
 }

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/BusinessException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/BusinessException.java
@@ -12,8 +12,8 @@ public class BusinessException extends RuntimeException {
 		this.detail = errorCode.getMessage();
 	}
 
-	public BusinessException(ErrorCode errorCode, String detail) {
+	public BusinessException(ErrorCode errorCode, Object...args) {
 		this.errorCode = errorCode;
-		this.detail = String.format("%s (%s)", errorCode.getMessage(), detail);
+		this.detail = String.format(errorCode.getMessage(), args);
 	}
 }

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/EntityNotFoundException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/EntityNotFoundException.java
@@ -5,7 +5,7 @@ public class EntityNotFoundException extends BusinessException {
 		super(errorCode);
 	}
 
-	public EntityNotFoundException(ErrorCode errorCode, String detail) {
-		super(errorCode, detail);
+	public EntityNotFoundException(ErrorCode errorCode, Object... args) {
+		super(errorCode, args);
 	}
 }

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
 	INVALID_COUPON_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "CO_002", "쿠폰의 유효기간이 잘못되었습니다."),
 	INVALID_COUPON_STRATEGY(HttpStatus.INTERNAL_SERVER_ERROR, "CO_003", "유효하지 않은 비율정책입니다."),
 	COUPON_ALREADY_USE(HttpStatus.BAD_REQUEST, "CO_004", "The coupon id = %d has already been used."),
+	COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "CO_005", "The coupon(id = %d, name=%s) already exist."),
+	COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, "CO_006", "If there are no coupons available for the coupon IDs: %s, an exception will be thrown"),
 
 
 	INVALID_MAINTENANCE_TIME(HttpStatus.INTERNAL_SERVER_ERROR, "B_001", "은행 점검기간이 유효하게 설정되지 않았습니다."),

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -16,15 +16,18 @@ public enum ErrorCode {
 	NOT_EMPTY(HttpStatus.BAD_REQUEST, "C_002", "값이 필요합니다."),
 	INVALID_STATE(HttpStatus.BAD_REQUEST, "C_003", "유효하지 않은 상태입니다."),
 
-	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M_002", "유효하지 않은 이메일 형식입니다."),
+	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M_001", "유효하지 않은 이메일 형식입니다."),
 	INVALID_PHONE_NUMBER_FORMAT(HttpStatus.BAD_REQUEST, "M_002", "유효하지 않은 전화번호 형식입니다."),
+	MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "M_003", "이미 '%s'라는 이메일로 가입된 계정이 존재합니다."),
+	MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_004", "멤버(id = %d)가 존재하지 않습니다."),
+
 
 	EXPIRED_COUPON_ERROR(HttpStatus.BAD_REQUEST, "CO_001", "이미 만료된 쿠폰입니다."),
 	INVALID_COUPON_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "CO_002", "쿠폰의 유효기간이 잘못되었습니다."),
 	INVALID_COUPON_STRATEGY(HttpStatus.INTERNAL_SERVER_ERROR, "CO_003", "유효하지 않은 비율정책입니다."),
-	COUPON_ALREADY_USE(HttpStatus.BAD_REQUEST, "CO_004", "The coupon id = %d has already been used."),
-	COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "CO_005", "The coupon(id = %d, name=%s) already exist."),
-	COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, "CO_006", "If there are no coupons available for the coupon IDs: %s, an exception will be thrown"),
+	COUPON_ALREADY_USE(HttpStatus.BAD_REQUEST, "CO_004", "이미 사용한 쿠폰(id = %d, 이름 = %s) 입니다."),
+	COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "CO_005", "이미 발급받은 쿠폰(id = %d, 이름 = %s) 입니다."),
+	COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, "CO_006", "사용할 수 있는 쿠폰 id 중에 %s에 해당하는 쿠폰들이 없습니다."),
 
 
 	INVALID_MAINTENANCE_TIME(HttpStatus.INTERNAL_SERVER_ERROR, "B_001", "은행 점검기간이 유효하게 설정되지 않았습니다."),

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_004", "멤버(id = %d)가 존재하지 않습니다."),
 
 
-	EXPIRED_COUPON_ERROR(HttpStatus.BAD_REQUEST, "CO_001", "이미 만료된 쿠폰입니다."),
+	COUPON_EXPIRED_ERROR(HttpStatus.BAD_REQUEST, "CO_001", "유효하지 않은 쿠폰입니다."),
 	INVALID_COUPON_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "CO_002", "쿠폰의 유효기간이 잘못되었습니다."),
 	INVALID_COUPON_STRATEGY(HttpStatus.INTERNAL_SERVER_ERROR, "CO_003", "유효하지 않은 비율정책입니다."),
 	COUPON_ALREADY_USE(HttpStatus.BAD_REQUEST, "CO_004", "이미 사용한 쿠폰(id = %d, 이름 = %s) 입니다."),

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
 	EXPIRED_COUPON_ERROR(HttpStatus.BAD_REQUEST, "CO_001", "이미 만료된 쿠폰입니다."),
 	INVALID_COUPON_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "CO_002", "쿠폰의 유효기간이 잘못되었습니다."),
 	INVALID_COUPON_STRATEGY(HttpStatus.INTERNAL_SERVER_ERROR, "CO_003", "유효하지 않은 비율정책입니다."),
+	COUPON_ALREADY_USE(HttpStatus.BAD_REQUEST, "CO_004", "The coupon id = %d has already been used."),
+
 
 	INVALID_MAINTENANCE_TIME(HttpStatus.INTERNAL_SERVER_ERROR, "B_001", "은행 점검기간이 유효하게 설정되지 않았습니다."),
 

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
@@ -10,6 +10,8 @@ import com.github.msafriends.modulecommon.dto.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.stream.Collectors;
+
 @Slf4j
 @RestControllerAdvice
 public class RestApiExceptionHandler {
@@ -36,7 +38,10 @@ public class RestApiExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+		String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+				.map(error -> String.format("%s %s", error.getField(), error.getDefaultMessage()))
+				.collect(Collectors.joining(","));
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, errorMessage);
 		log.debug("Argument validation has failed: {}", ex.getMessage());
 		return new ResponseEntity<>(response, response.getStatus());
 	}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.github.msafriends.modulecommon.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +11,7 @@ import com.github.msafriends.modulecommon.dto.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -38,10 +40,10 @@ public class RestApiExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-		String errorMessage = ex.getBindingResult().getFieldErrors().stream()
-				.map(error -> String.format("%s %s", error.getField(), error.getDefaultMessage()))
-				.collect(Collectors.joining(","));
-		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, errorMessage);
+		Map<String, String> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+				.collect(Collectors.toMap(FieldError::getField, error -> error.getDefaultMessage() != null ? error.getDefaultMessage() : ""));
+
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, fieldErrors);
 		log.debug("Argument validation has failed: {}", ex.getMessage());
 		return new ResponseEntity<>(response, response.getStatus());
 	}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/RestApiExceptionHandler.java
@@ -43,8 +43,8 @@ public class RestApiExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
-		ErrorResponse response = ErrorResponse.of(ex.getErrorCode());
-		log.error("Unexpected error has occurred: {}", ex.getMessage(), ex);
+		ErrorResponse response = ErrorResponse.of(ex.getErrorCode(), ex.getDetail());
+		log.error("Unexpected error has occurred: {}", ex.getDetail(), ex);
 		return new ResponseEntity<>(response, response.getStatus());
 	}
 

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyIssuedException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyIssuedException.java
@@ -1,0 +1,10 @@
+package com.github.msafriends.modulecommon.exception.member.coupon;
+
+import com.github.msafriends.modulecommon.exception.BusinessException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class CouponAlreadyIssuedException extends BusinessException {
+    public CouponAlreadyIssuedException(Long couponId, String couponName) {
+        super(ErrorCode.COUPON_ALREADY_ISSUED, couponId, couponName);
+    }
+}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyUseException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyUseException.java
@@ -5,7 +5,7 @@ import com.github.msafriends.modulecommon.exception.ErrorCode;
 
 public class CouponAlreadyUseException extends BusinessException {
 
-    public CouponAlreadyUseException(Long alreadyUseCouponId) {
-        super(ErrorCode.COUPON_ALREADY_USE, alreadyUseCouponId);
+    public CouponAlreadyUseException(Long alreadyUseMemberCouponId, String alreadyUseMemberCouponName) {
+        super(ErrorCode.COUPON_ALREADY_USE, alreadyUseMemberCouponId, alreadyUseMemberCouponName);
     }
 }

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyUseException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponAlreadyUseException.java
@@ -1,0 +1,11 @@
+package com.github.msafriends.modulecommon.exception.member.coupon;
+
+import com.github.msafriends.modulecommon.exception.BusinessException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class CouponAlreadyUseException extends BusinessException {
+
+    public CouponAlreadyUseException(Long alreadyUseCouponId) {
+        super(ErrorCode.COUPON_ALREADY_USE, alreadyUseCouponId);
+    }
+}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponExpiredException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponExpiredException.java
@@ -1,0 +1,11 @@
+package com.github.msafriends.modulecommon.exception.member.coupon;
+
+import com.github.msafriends.modulecommon.exception.BusinessException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class CouponExpiredException extends BusinessException {
+
+    public CouponExpiredException() {
+        super(ErrorCode.COUPON_EXPIRED_ERROR);
+    }
+}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponNotExistException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/coupon/CouponNotExistException.java
@@ -1,0 +1,12 @@
+package com.github.msafriends.modulecommon.exception.member.coupon;
+
+import com.github.msafriends.modulecommon.exception.EntityNotFoundException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+import java.util.List;
+
+public class CouponNotExistException extends EntityNotFoundException {
+    public CouponNotExistException(List<Long> couponIds) {
+        super(ErrorCode.COUPON_NOT_EXIST, couponIds);
+    }
+}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/member/MemberAlreadyExistException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/member/MemberAlreadyExistException.java
@@ -1,0 +1,10 @@
+package com.github.msafriends.modulecommon.exception.member.member;
+
+import com.github.msafriends.modulecommon.exception.BusinessException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class MemberAlreadyExistException extends BusinessException {
+    public MemberAlreadyExistException(String email) {
+        super(ErrorCode.MEMBER_ALREADY_EXIST, email);
+    }
+}

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/member/MemberNotExistException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/member/member/MemberNotExistException.java
@@ -1,0 +1,11 @@
+package com.github.msafriends.modulecommon.exception.member.member;
+
+import com.github.msafriends.modulecommon.exception.EntityNotFoundException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class MemberNotExistException extends EntityNotFoundException {
+
+    public MemberNotExistException(Long memberId) {
+        super(ErrorCode.MEMBER_NOT_EXIST, memberId);
+    }
+}

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/controller/internal/member/MemberInternalControllerV1.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/controller/internal/member/MemberInternalControllerV1.java
@@ -27,5 +27,4 @@ public class MemberInternalControllerV1 {
             @RequestBody MemberCouponUseRequest request) {
         return ResponseEntity.ok(memberCouponService.useMemberCoupons(memberId, request, LocalDateTime.now()));
     }
-
 }

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/controller/internal/member/MemberInternalControllerV1.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/controller/internal/member/MemberInternalControllerV1.java
@@ -1,14 +1,14 @@
 package com.github.msafriends.moduleapi.controller.internal.member;
 
+import com.github.msafriends.moduleapi.dto.request.member.MemberCouponUseRequest;
 import com.github.msafriends.moduleapi.dto.response.ListResponse;
 import com.github.msafriends.moduleapi.dto.response.coupon.MemberCouponResponse;
 import com.github.msafriends.moduleapi.service.MemberCouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +18,14 @@ public class MemberInternalControllerV1 {
 
     @GetMapping("/{memberId}/coupons")
     public ResponseEntity<ListResponse<MemberCouponResponse>> getCoupons(@PathVariable Long memberId) {
-        return ResponseEntity.ok(memberCouponService.getMemberCoupons(memberId));
+        return ResponseEntity.ok(memberCouponService.getMemberCoupons(memberId, LocalDateTime.now()));
     }
+
+    @PostMapping("/{memberId}/coupons")
+    public ResponseEntity<ListResponse<MemberCouponResponse>> useCoupons(
+            @PathVariable Long memberId,
+            @RequestBody MemberCouponUseRequest request) {
+        return ResponseEntity.ok(memberCouponService.useMemberCoupons(memberId, request, LocalDateTime.now()));
+    }
+
 }

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/dto/request/member/MemberCouponUseRequest.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/dto/request/member/MemberCouponUseRequest.java
@@ -1,0 +1,17 @@
+package com.github.msafriends.moduleapi.dto.request.member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberCouponUseRequest {
+    private List<Long> memberCouponIds;
+
+    public MemberCouponUseRequest(final List<Long> memberCouponIds) {
+        this.memberCouponIds = memberCouponIds;
+    }
+}

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/dto/request/member/MemberSignupRequest.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/dto/request/member/MemberSignupRequest.java
@@ -1,9 +1,9 @@
 package com.github.msafriends.moduleapi.dto.request.member;
 
 import com.github.msafriends.modulecore.domain.member.Member;
-import com.github.msafriends.moduleapi.validator.anntations.ValidMemberName;
-import com.github.msafriends.moduleapi.validator.anntations.ValidPassword;
-import com.github.msafriends.moduleapi.validator.anntations.ValidPhoneNumber;
+import com.github.msafriends.moduleapi.validator.annotations.ValidMemberName;
+import com.github.msafriends.moduleapi.validator.annotations.ValidPassword;
+import com.github.msafriends.moduleapi.validator.annotations.ValidPhoneNumber;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
@@ -2,6 +2,7 @@ package com.github.msafriends.moduleapi.service;
 
 import com.github.msafriends.moduleapi.dto.request.member.MemberCouponCommand;
 import com.github.msafriends.moduleapi.dto.request.member.MemberCouponRequest;
+import com.github.msafriends.moduleapi.dto.request.member.MemberCouponUseRequest;
 import com.github.msafriends.moduleapi.dto.response.ListResponse;
 import com.github.msafriends.moduleapi.dto.response.coupon.MemberCouponResponse;
 import com.github.msafriends.modulecore.domain.coupon.Coupon;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,12 +25,44 @@ public class MemberCouponService {
     private final MemberRepository memberRepository;
     private final CouponRepository couponRepository;
 
-    public ListResponse<MemberCouponResponse> getMemberCoupons(Long memberId) {
+    public ListResponse<MemberCouponResponse> getMemberCoupons(Long memberId, LocalDateTime currentTime) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));
 
         List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberAndHasUsed(member, false);
+        List<MemberCouponResponse> memberCouponResponses = memberCoupons.stream()
+                .filter(memberCoupon -> memberCoupon.hasValidRangeCouponUse(currentTime))
+                .map(MemberCouponResponse::from).toList();
+
+        return new ListResponse<>(
+                memberCouponResponses.size(),
+                memberCouponResponses
+        );
+    }
+
+    public ListResponse<MemberCouponResponse> useMemberCoupons(Long memberId, MemberCouponUseRequest request, LocalDateTime currentTime) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));
+        List<MemberCoupon> memberCoupons = member.getMemberCoupons().stream()
+                .filter(memberCoupon -> request.getMemberCouponIds().contains(memberCoupon.getId()))
+                .filter(memberCoupon -> memberCoupon.hasValidRangeCouponUse(currentTime))
+                .peek(memberCoupon -> memberCoupon.use(currentTime))
+                .toList();
+
+        validateRequestedCouponsExist(request, memberCoupons);
+
+        memberCouponRepository.saveAll(memberCoupons);
+
         return new ListResponse<>(memberCoupons.size(), memberCoupons.stream().map(MemberCouponResponse::from).toList());
     }
+
+    private void validateRequestedCouponsExist(MemberCouponUseRequest request, List<MemberCoupon> memberCoupons) {
+        List<Long> missingCouponIds = request.getMemberCouponIds().stream()
+                .filter(requestedCouponId -> memberCoupons.stream().noneMatch(memberCoupon -> memberCoupon.getId().equals(requestedCouponId))).toList();
+
+        if (!missingCouponIds.isEmpty()) {
+            throw new RuntimeException("사용할 수 있는 쿠폰 중에 쿠폰 ID " + missingCouponIds + "에 해당하는 쿠폰이 없습니다.");
+        }
+    }
+
 
     public MemberCouponResponse generateMemberCoupon(Long memberId, MemberCouponRequest request) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
@@ -5,6 +5,8 @@ import com.github.msafriends.moduleapi.dto.request.member.MemberCouponRequest;
 import com.github.msafriends.moduleapi.dto.request.member.MemberCouponUseRequest;
 import com.github.msafriends.moduleapi.dto.response.ListResponse;
 import com.github.msafriends.moduleapi.dto.response.coupon.MemberCouponResponse;
+import com.github.msafriends.modulecommon.exception.member.coupon.CouponAlreadyIssuedException;
+import com.github.msafriends.modulecommon.exception.member.coupon.CouponNotExistException;
 import com.github.msafriends.modulecore.domain.coupon.Coupon;
 import com.github.msafriends.modulecore.domain.coupon.MemberCoupon;
 import com.github.msafriends.modulecore.domain.member.Member;
@@ -16,7 +18,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,7 +60,7 @@ public class MemberCouponService {
                 .filter(requestedCouponId -> memberCoupons.stream().noneMatch(memberCoupon -> memberCoupon.getId().equals(requestedCouponId))).toList();
 
         if (!missingCouponIds.isEmpty()) {
-            throw new RuntimeException("사용할 수 있는 쿠폰 중에 쿠폰 ID " + missingCouponIds + "에 해당하는 쿠폰이 없습니다.");
+            throw new CouponNotExistException(missingCouponIds);
         }
     }
 
@@ -77,7 +78,7 @@ public class MemberCouponService {
 
     private void validateHasMemberCouponAlready(Member member, Coupon coupon) {
         memberCouponRepository.findMemberCouponsByMemberAndCoupon(member, coupon).ifPresent(existingMemberCoupon -> {
-                    throw new RuntimeException("memberCoupon already exists.");
+                    throw new CouponAlreadyIssuedException(existingMemberCoupon.getId(), existingMemberCoupon.getCoupon().getName());
                 }
         );
     }

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberCouponService.java
@@ -26,7 +26,7 @@ public class MemberCouponService {
     private final CouponRepository couponRepository;
 
     public ListResponse<MemberCouponResponse> getMemberCoupons(Long memberId, LocalDateTime currentTime) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));
+        Member member = memberRepository.findByEmailOrElseThrow(memberId);
 
         List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberAndHasUsed(member, false);
         List<MemberCouponResponse> memberCouponResponses = memberCoupons.stream()
@@ -40,7 +40,7 @@ public class MemberCouponService {
     }
 
     public ListResponse<MemberCouponResponse> useMemberCoupons(Long memberId, MemberCouponUseRequest request, LocalDateTime currentTime) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));
+        Member member = memberRepository.findByEmailOrElseThrow(memberId);
         List<MemberCoupon> memberCoupons = member.getMemberCoupons().stream()
                 .filter(memberCoupon -> request.getMemberCouponIds().contains(memberCoupon.getId()))
                 .filter(memberCoupon -> memberCoupon.hasValidRangeCouponUse(currentTime))
@@ -65,7 +65,7 @@ public class MemberCouponService {
 
 
     public MemberCouponResponse generateMemberCoupon(Long memberId, MemberCouponRequest request) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not exist."));
+        Member member = memberRepository.findByEmailOrElseThrow(memberId);
         Coupon coupon = couponRepository.findById(request.getCouponId()).orElseThrow(() -> new RuntimeException("Coupon not exist."));
 
         validateHasMemberCouponAlready(member, coupon);

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberService.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/service/MemberService.java
@@ -2,6 +2,7 @@ package com.github.msafriends.moduleapi.service;
 
 import com.github.msafriends.moduleapi.dto.request.member.MemberSignupRequest;
 import com.github.msafriends.moduleapi.dto.response.member.MemberSignupResponse;
+import com.github.msafriends.modulecommon.exception.member.member.MemberAlreadyExistException;
 import com.github.msafriends.modulecore.domain.coupon.Coupon;
 import com.github.msafriends.modulecore.domain.coupon.CouponGenerateType;
 import com.github.msafriends.modulecore.domain.coupon.MemberCoupon;
@@ -27,7 +28,7 @@ public class MemberService {
     public MemberSignupResponse createMember(MemberSignupRequest memberSignupRequest) {
         Member member = memberSignupRequest.toMember();
         memberRepository.findByEmail(member.getEmail()).ifPresent(existingMember -> {
-            throw new RuntimeException("Member already exists.");
+            throw new MemberAlreadyExistException(existingMember.getEmail().getValue());
         });
 
         memberRepository.save(member);

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/MemberNameValidator.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/MemberNameValidator.java
@@ -1,6 +1,6 @@
 package com.github.msafriends.moduleapi.validator;
 
-import com.github.msafriends.moduleapi.validator.anntations.ValidMemberName;
+import com.github.msafriends.moduleapi.validator.annotations.ValidMemberName;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/PasswordValidator.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/PasswordValidator.java
@@ -1,6 +1,6 @@
 package com.github.msafriends.moduleapi.validator;
 
-import com.github.msafriends.moduleapi.validator.anntations.ValidPassword;
+import com.github.msafriends.moduleapi.validator.annotations.ValidPassword;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/PhoneNumberValidator.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/PhoneNumberValidator.java
@@ -1,6 +1,6 @@
 package com.github.msafriends.moduleapi.validator;
 
-import com.github.msafriends.moduleapi.validator.anntations.ValidPhoneNumber;
+import com.github.msafriends.moduleapi.validator.annotations.ValidPhoneNumber;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidMemberName.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidMemberName.java
@@ -1,4 +1,4 @@
-package com.github.msafriends.moduleapi.validator.anntations;
+package com.github.msafriends.moduleapi.validator.annotations;
 
 import com.github.msafriends.moduleapi.validator.MemberNameValidator;
 import jakarta.validation.Constraint;

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidPassword.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidPassword.java
@@ -1,4 +1,4 @@
-package com.github.msafriends.moduleapi.validator.anntations;
+package com.github.msafriends.moduleapi.validator.annotations;
 
 import com.github.msafriends.moduleapi.validator.PasswordValidator;
 import jakarta.validation.Constraint;

--- a/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidPhoneNumber.java
+++ b/service-member/module-api/src/main/java/com/github/msafriends/moduleapi/validator/annotations/ValidPhoneNumber.java
@@ -1,4 +1,4 @@
-package com.github.msafriends.moduleapi.validator.anntations;
+package com.github.msafriends.moduleapi.validator.annotations;
 
 import com.github.msafriends.moduleapi.validator.PhoneNumberValidator;
 import jakarta.validation.Constraint;

--- a/service-member/module-core/build.gradle
+++ b/service-member/module-core/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     api ('org.springframework.boot:spring-boot-starter-data-jpa')
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 bootJar {

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
@@ -1,5 +1,6 @@
 package com.github.msafriends.modulecore.domain.coupon;
 
+import com.github.msafriends.modulecommon.exception.member.coupon.CouponAlreadyUseException;
 import com.github.msafriends.modulecore.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -51,7 +52,7 @@ public class MemberCoupon {
 
     public void use(LocalDateTime currentTime) {
         if (this.hasUsed) {
-            throw new IllegalStateException("The coupon with ID " + this.getId() + " has already been used.");
+            throw new CouponAlreadyUseException(this.getId());
         }
         if (!hasValidRangeCouponUse(currentTime)) {
             throw new IllegalStateException("The coupon is not within its validity period.");

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
@@ -52,7 +52,7 @@ public class MemberCoupon {
 
     public void use(LocalDateTime currentTime) {
         if (this.hasUsed) {
-            throw new CouponAlreadyUseException(this.getId());
+            throw new CouponAlreadyUseException(this.getId(), this.coupon.getName());
         }
         if (!hasValidRangeCouponUse(currentTime)) {
             throw new IllegalStateException("The coupon is not within its validity period.");

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
@@ -1,6 +1,7 @@
 package com.github.msafriends.modulecore.domain.coupon;
 
 import com.github.msafriends.modulecommon.exception.member.coupon.CouponAlreadyUseException;
+import com.github.msafriends.modulecommon.exception.member.coupon.CouponExpiredException;
 import com.github.msafriends.modulecore.domain.member.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -55,7 +56,7 @@ public class MemberCoupon {
             throw new CouponAlreadyUseException(this.getId(), this.coupon.getName());
         }
         if (!hasValidRangeCouponUse(currentTime)) {
-            throw new IllegalStateException("The coupon is not within its validity period.");
+            throw new CouponExpiredException();
         }
         this.hasUsed = true;
         this.usedAt = LocalDateTime.now();

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/domain/coupon/MemberCoupon.java
@@ -50,18 +50,18 @@ public class MemberCoupon {
     }
 
     public void use(LocalDateTime currentTime) {
-        checkCouponValidity(currentTime);
         if (this.hasUsed) {
-            throw new IllegalStateException("The coupon has already been used.");
+            throw new IllegalStateException("The coupon with ID " + this.getId() + " has already been used.");
+        }
+        if (!hasValidRangeCouponUse(currentTime)) {
+            throw new IllegalStateException("The coupon is not within its validity period.");
         }
         this.hasUsed = true;
         this.usedAt = LocalDateTime.now();
     }
 
-    private void checkCouponValidity(LocalDateTime currentTime) {
-        if (currentTime.isBefore(startAt) || currentTime.isAfter(endAt)) {
-            throw new IllegalStateException("The coupon is not within its validity period.");
-        }
+    public boolean hasValidRangeCouponUse(LocalDateTime currentTime) {
+        return currentTime.isAfter(startAt) || currentTime.isBefore(endAt);
     }
 
     private void validateCouponExpirationDateCorrectness(LocalDateTime startAt, LocalDateTime endAt) {

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/repository/member/MemberRepository.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/repository/member/MemberRepository.java
@@ -10,4 +10,10 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(Email email);
+
+    default Member findByEmailOrElseThrow(Long memberId) {
+        return this.findById(memberId).orElseThrow(() ->
+                new RuntimeException("Member not exist.")
+        );
+    }
 }

--- a/service-member/module-core/src/main/java/com/github/msafriends/modulecore/repository/member/MemberRepository.java
+++ b/service-member/module-core/src/main/java/com/github/msafriends/modulecore/repository/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.github.msafriends.modulecore.repository.member;
 
+import com.github.msafriends.modulecommon.exception.member.member.MemberNotExistException;
 import com.github.msafriends.modulecore.domain.member.Email;
 import com.github.msafriends.modulecore.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,7 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member findByEmailOrElseThrow(Long memberId) {
         return this.findById(memberId).orElseThrow(() ->
-                new RuntimeException("Member not exist.")
+                new MemberNotExistException(memberId)
         );
     }
 }


### PR DESCRIPTION
## What is this PR do?
- 주문시에 사용할 coupon id list를 받을 시에 coupon들을 사용할 수 있는 api 개발
- Custom exception들에 대한 정의와 RestApiExceptionHandler 리팩토링

## Changes
- [x] : coupon use internal API
  - [x] : 멤버가 현재 가지고 있는 쿠폰 id 리스트가 들어올 경우에 대한 validation
  - [x] : 이미 사용한 쿠폰에 대해 사용할 경우 validation  
- [x] : Custom exceptions
  - [x] : CouponAlreadyIssuedException
  - [x] : CouponAlreadyUseException
  - [x] : CouponNotExistException 
  - [x] : MemberAlreadyExistException
  - [x] : MemberNotExistException
- [x] :  RestApiExceptionHandler 리팩토링
  - [x] : handleBusinessException 에 대해 detail field를 포함한 ErrorResponse 객체를 만들 수 있도록 로직 개선
  - [x] : MethodArgumentNotValidException에 대해 Validator에서 나온 exception에 대해 bindResult에서 message를 가져올 수 있도록 로직 개선  

## Tests
- [x] : 멤버가 가지고 있지 않은 쿠폰을 사용하려한 경우
```json
{
    "message": "사용할 수 있는 쿠폰 id 중에 [4, 5]에 해당하는 쿠폰들이 없습니다.",
    "code": "CO_006"
}
```
- [x] : 이미 사용한 쿠폰을 사용하려한 경우
```json
{
    "message": "이미 사용한 쿠폰(id = 1, 이름 = 1000원 할인 쿠폰) 입니다.",
    "code": "CO_004"
}
```