### PR TITLE
[product-service] 상품 재고 증감 API 개발

### DIFF
--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -38,9 +38,11 @@ public enum ErrorCode {
 	INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "CA_002", "유효하지 않은 카드 유효기간 날짜 형식입니다."),
 	INVALID_PASSWORD_ERROR(HttpStatus.BAD_REQUEST, "CA_003", "잘못된 비밀번호 입니다."),
 
+
 	INVALID_PRICE_ERROR(HttpStatus.BAD_REQUEST, "P_001", "유효하지 않은 가격입니다."),
 	INVALID_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "P_002", "유효하지 않은 수량입니다."),
-	INVALID_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "P_003", "재고가 충분하지 않습니다. (id = %d, remain = %d)");
+	INVALID_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "P_003", "재고가 충분하지 않습니다. (id = %d, remain = %d)"),
+	INVALID_ORDER_ERROR(HttpStatus.BAD_REQUEST, "P_004", "유효하지 않은 주문입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
 	INVALID_PASSWORD_ERROR(HttpStatus.BAD_REQUEST, "CA_003", "잘못된 비밀번호 입니다."),
 
 	INVALID_PRICE_ERROR(HttpStatus.BAD_REQUEST, "P_001", "유효하지 않은 가격입니다."),
-	INVALID_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "P_002", "유효하지 않은 수량입니다.");
+	INVALID_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "P_002", "유효하지 않은 수량입니다."),
+	INVALID_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "P_003", "재고가 충분하지 않습니다. (id = %d, remain = %d)");
 
 	private final HttpStatus status;
 	private final String code;

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/product/NotEnoughStockException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/product/NotEnoughStockException.java
@@ -1,0 +1,10 @@
+package com.github.msafriends.modulecommon.exception.product;
+
+import com.github.msafriends.modulecommon.exception.BusinessException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+
+public class NotEnoughStockException extends BusinessException {
+    public NotEnoughStockException(Long productId, int stockQuantity){
+        super(ErrorCode.INVALID_ORDER_QUANTITY, productId, stockQuantity);
+    }
+}

--- a/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/controller/internal/v1/ProductInternalApiControllerV1.java
+++ b/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/controller/internal/v1/ProductInternalApiControllerV1.java
@@ -1,6 +1,7 @@
 package com.github.msafriends.serviceproduct.moduleapi.controller.internal.v1;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -11,16 +12,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.msafriends.serviceproduct.moduleapi.dto.ProductRequest;
+import com.github.msafriends.serviceproduct.moduleapi.dto.UpdateStockRequest;
 import com.github.msafriends.serviceproduct.moduleapi.service.ProductService;
+
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/internal/v1")
+@RequestMapping("/api/internal/v1/products")
 public class ProductInternalApiControllerV1 {
 	private final ProductService productService;
 
-	@PostMapping("/products")
+	@PostMapping
 	public ResponseEntity<Void> save(
 		@RequestHeader("Seller-Id") Long sellerId,
 		@Validated @RequestBody ProductRequest request
@@ -31,5 +34,11 @@ public class ProductInternalApiControllerV1 {
 					+ productService.registerProduct(request.toEntity(sellerId)))
 			)
 			.build();
+	}
+
+	@PostMapping("/stocks")
+	public ResponseEntity<Void> bulkUpdateProductStocks(@RequestBody List<UpdateStockRequest> requests){
+		productService.updateStocks(requests);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/dto/UpdateStockRequest.java
+++ b/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/dto/UpdateStockRequest.java
@@ -1,0 +1,21 @@
+package com.github.msafriends.serviceproduct.moduleapi.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateStockRequest {
+    @NotNull
+    private Long productId;
+    private int quantity;
+
+    @Builder
+    public UpdateStockRequest(Long productId, int quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+}

--- a/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductService.java
+++ b/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductService.java
@@ -1,8 +1,13 @@
 package com.github.msafriends.serviceproduct.moduleapi.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.msafriends.serviceproduct.moduleapi.dto.UpdateStockRequest;
 import com.github.msafriends.serviceproduct.modulecore.domain.category.Category;
 import com.github.msafriends.serviceproduct.modulecore.repository.CategoryRepository;
 import com.github.msafriends.serviceproduct.modulecore.repository.ProductRepository;
@@ -29,5 +34,16 @@ public class ProductService {
 	@Transactional
 	public Long registerProduct(Product product){
 		return productRepository.save(product).getId();
+	}
+
+	@Transactional
+	public void updateStocks(List<UpdateStockRequest> updateStockRequests){
+		List<Long> orderedIds = updateStockRequests.stream()
+            .map(UpdateStockRequest::getProductId)
+			.toList();
+		Map<Long, Integer> requestMap = updateStockRequests.stream()
+			.collect(Collectors.toMap(UpdateStockRequest::getProductId, UpdateStockRequest::getQuantity));
+		List<Product> foundProducts = productRepository.findProductsByIdIn(orderedIds);
+		foundProducts.forEach(product -> product.updateStockQuantity(requestMap.get(product.getId())));
 	}
 }

--- a/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductService.java
+++ b/service-product/module-api/src/main/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductService.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.msafriends.modulecommon.exception.EntityNotFoundException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
 import com.github.msafriends.serviceproduct.moduleapi.dto.UpdateStockRequest;
 import com.github.msafriends.serviceproduct.modulecore.domain.category.Category;
 import com.github.msafriends.serviceproduct.modulecore.repository.CategoryRepository;
@@ -44,6 +46,8 @@ public class ProductService {
 		Map<Long, Integer> requestMap = updateStockRequests.stream()
 			.collect(Collectors.toMap(UpdateStockRequest::getProductId, UpdateStockRequest::getQuantity));
 		List<Product> foundProducts = productRepository.findProductsByIdIn(orderedIds);
+		if(orderedIds.size() != foundProducts.size())
+			throw new EntityNotFoundException(ErrorCode.INVALID_ORDER_ERROR, "유효하지 않은 상품 id가 주문에 포함되어 있습니다.");
 		foundProducts.forEach(product -> product.updateStockQuantity(requestMap.get(product.getId())));
 	}
 }

--- a/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/common/fixture/product/ProductFixture.java
+++ b/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/common/fixture/product/ProductFixture.java
@@ -1,10 +1,16 @@
 package com.github.msafriends.serviceproduct.common.fixture.product;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.Assert;
 
 import com.github.msafriends.serviceproduct.moduleapi.dto.ProductRequest;
 
 import com.github.msafriends.serviceproduct.common.fixture.category.CategoryFixture;
+import com.github.msafriends.serviceproduct.moduleapi.dto.UpdateStockRequest;
 import com.github.msafriends.serviceproduct.modulecore.domain.product.AgeLimit;
 import com.github.msafriends.serviceproduct.modulecore.domain.product.Benefit;
 import com.github.msafriends.serviceproduct.modulecore.domain.product.Price;
@@ -69,6 +75,30 @@ public class ProductFixture {
                 .benefit(createDefaultBenefit())
                 .build();
     }
+    public static Product createProductWithQuantity(int quantity) {
+        return Product.builder()
+            .sellerId(SELLER_ID)
+            .quantity(quantity)
+            .code(CODE)
+            .price(DEFAULT_PRICE)
+            .name(NAME)
+            .delivery(DELIVERY)
+            .buySatisfy(BUY_SATISFY)
+            .ageLimit(AGE_LIMIT)
+            .size(DEFAULT_SIZE)
+            .benefit(createDefaultBenefit())
+            .build();
+    }
+
+    public static List<UpdateStockRequest> createUpdateStockRequestList(int productNumbers, int...quantities){
+        if(productNumbers != quantities.length)
+            Assert.state(false, "not valid test condition");
+        List<UpdateStockRequest> requests = new ArrayList<>();
+        for (int i = 1; i <= quantities.length; i++) {
+            requests.add(UpdateStockRequest.builder().productId((long)i).quantity(quantities[i - 1]).build());
+        }
+        return requests;
+    }
 
     public static ProductRequest createProductRequest(){
         return ProductRequest.builder()
@@ -84,12 +114,19 @@ public class ProductFixture {
             .build();
     }
 
-    public static Product createProductWithId(Long id){
-        Product product = createProduct();
+    public static Product createProductWithIdAndQuantity(Long id, int quantity){
+        Product product = createProductWithQuantity(quantity);
         ReflectionTestUtils.setField(product, "id", id);
         return product;
     }
 
+    public static List<Product> createOrderedProduct(int fixedQuantity,int productNumbers){
+        List<Product> orderedProducts = new ArrayList<>();
+        for (int i = 1; i <= productNumbers; i++) {
+            orderedProducts.add(createProductWithIdAndQuantity((long)i, fixedQuantity));
+        }
+        return orderedProducts;
+    }
 
     public static Product createInvalidPriceProduct(int price, int salePrice) {
         return Product.builder()

--- a/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/moduleapi/controller/internal/v1/ProductControllerTest.java
+++ b/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/moduleapi/controller/internal/v1/ProductControllerTest.java
@@ -45,4 +45,15 @@ class ProductControllerTest extends AcceptanceTest {
 			.andExpect(status().isCreated())
 			.andExpect(redirectedUrl("/api/internal/v1/products/" + 1L));
 	}
+
+	@Test
+	@DisplayName("주문 재고 증감 API 테스트")
+	void bulkUpdateStockTest() throws Exception {
+		//given
+		ResultActions action = mockMvc.perform(MockMvcRequestBuilders.post("/api/internal/v1/products/stocks")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createUpdateStockRequestList(3, -2, -3, -5)))
+		);
+		action.andExpect(status().isOk());
+	}
 }

--- a/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductServiceTest.java
+++ b/service-product/module-api/src/test/java/com/github/msafriends/serviceproduct/moduleapi/service/ProductServiceTest.java
@@ -1,7 +1,11 @@
 package com.github.msafriends.serviceproduct.moduleapi.service;
 
 import static com.github.msafriends.serviceproduct.common.fixture.product.ProductFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+import com.github.msafriends.modulecommon.exception.product.NotEnoughStockException;
 import com.github.msafriends.serviceproduct.common.fixture.category.CategoryFixture;
+import com.github.msafriends.serviceproduct.moduleapi.dto.UpdateStockRequest;
 import com.github.msafriends.serviceproduct.modulecore.domain.product.Product;
 import com.github.msafriends.serviceproduct.modulecore.repository.CategoryRepository;
 import com.github.msafriends.serviceproduct.modulecore.repository.ProductRepository;
@@ -35,7 +42,7 @@ public class ProductServiceTest {
 		void registerSuccessTestWithOutCategory() throws Exception {
 			//given
 			Product product = createProduct();
-			when(productRepository.save(product)).thenReturn(createProductWithId(TEST_PRODUCT_ID));
+			when(productRepository.save(product)).thenReturn(createProductWithIdAndQuantity(TEST_PRODUCT_ID, 10));
 			//when
 			Long productId = productService.registerProduct(product);
 			//then
@@ -46,12 +53,43 @@ public class ProductServiceTest {
 		void registerSuccessTest() throws Exception {
 			//given
 			Product product = createProduct();
-			when(productRepository.save(product)).thenReturn(createProductWithId(TEST_PRODUCT_ID));
+			when(productRepository.save(product)).thenReturn(createProductWithIdAndQuantity(TEST_PRODUCT_ID, 10));
 			when(categoryRepository.findByIdOrThrow(CategoryFixture.MAIN_CATEGORY_ID_A)).thenReturn(CategoryFixture.createMainCategory(CategoryFixture.MAIN_CATEGORY_NAME));
 			//when
 			Long productId = productService.registerProduct(CategoryFixture.MAIN_CATEGORY_ID_A, product);
 			//then
 			Assertions.assertThat(productId).isEqualTo(TEST_PRODUCT_ID);
+		}
+	}
+
+	@Nested
+	@DisplayName("상품 정보 갱신 테스트")
+	class UpdateProductTest{
+		@Test
+		@DisplayName("주문 정보를 바탕으로 상품의 재고를 증감할 수 있다.")
+		void updateStockTest() throws Exception {
+			//given
+			List<UpdateStockRequest> updateStockRequestList = createUpdateStockRequestList(3, -4, -5, -6);
+			List<Product> orderedProduct = createOrderedProduct(10, 3);
+			when(productRepository.findProductsByIdIn(Arrays.asList(1L,2L,3L)))
+				.thenReturn(orderedProduct);
+			//when
+			assertDoesNotThrow(() -> productService.updateStocks(updateStockRequestList));
+		}
+
+		@Test
+		@DisplayName("주문 수량이 재고 수량 보다 많은 경우 예외를 발생시킨다.")
+		void invalidOrderQuantityTest() throws Exception {
+			//given
+			List<UpdateStockRequest> updateStockRequestList = createUpdateStockRequestList(3, -3, -12, -1);
+			when(productRepository.findProductsByIdIn(Arrays.asList(1L,2L,3L)))
+				.thenReturn(createOrderedProduct(10, 3));
+			//when
+			NotEnoughStockException notEnoughStockException = assertThrows(NotEnoughStockException.class,
+				() -> productService.updateStocks(updateStockRequestList));
+			//then
+			System.out.println(notEnoughStockException.getDetail());
+			Assertions.assertThat(notEnoughStockException.getErrorCode()).isEqualTo(ErrorCode.INVALID_ORDER_QUANTITY);
 		}
 	}
 }

--- a/service-product/module-core/src/main/java/com/github/msafriends/serviceproduct/modulecore/domain/product/Product.java
+++ b/service-product/module-core/src/main/java/com/github/msafriends/serviceproduct/modulecore/domain/product/Product.java
@@ -1,5 +1,6 @@
 package com.github.msafriends.serviceproduct.modulecore.domain.product;
 
+import com.github.msafriends.modulecommon.exception.product.NotEnoughStockException;
 import com.github.msafriends.serviceproduct.modulecore.domain.productimage.ProductImage;
 import com.github.msafriends.serviceproduct.modulecore.domain.category.Category;
 import com.github.msafriends.serviceproduct.modulecore.domain.review.ProductReview;
@@ -75,10 +76,6 @@ public class Product extends BaseTimeEntity {
         this.productImages = productImages;
     }
 
-    public void assignCategory(Category category){
-        this.category = category;
-    }
-
     private void validateProduct(Long sellerId, Long code, String name, String delivery, AgeLimit ageLimit, int quantity) {
         validateNotNull(sellerId, code, name, delivery, ageLimit);
         validateQuantity(quantity);
@@ -100,5 +97,15 @@ public class Product extends BaseTimeEntity {
         Assert.notNull(name, "name must not be null");
         Assert.notNull(delivery, "delivery must not be null");
         Assert.notNull(ageLimit, "isMinor must not be null");
+    }
+
+    public void assignCategory(Category category){
+        this.category = category;
+    }
+
+    public void updateStockQuantity(int orderedQuantity){
+        if(this.quantity + orderedQuantity < 0)
+            throw new NotEnoughStockException(id, quantity);
+        this.quantity += orderedQuantity;
     }
 }

--- a/service-product/module-core/src/main/java/com/github/msafriends/serviceproduct/modulecore/repository/ProductRepository.java
+++ b/service-product/module-core/src/main/java/com/github/msafriends/serviceproduct/modulecore/repository/ProductRepository.java
@@ -1,8 +1,11 @@
 package com.github.msafriends.serviceproduct.modulecore.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.github.msafriends.serviceproduct.modulecore.domain.product.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    public List<Product> findProductsByIdIn(List<Long> ids);
 }


### PR DESCRIPTION
## What is this PR do?
주문이 확정 되었을떄 주문수량에 따라 상품재고를 감소, 롤백시 재고를 증가시키는 API 개발
```text
- OrderMicroService는 상품 아이디와 각 상품별 주문 수량정보를 통해 재고를 증가, 감소 시킬 수 있다.
- 주문 수량 정보가 재고 수량 보다 크거나, 유효하지 않은 상품 id에 대한 요청은 에외를 발생시킨다.
```


## Tests
- [x] : 재고 감소 성공 테스트
- [x] : 재고 감소 실패 테스트

##요청

```code
POST /stocks

Description:
Bulk update product stocks.

Request Body:
- Content-Type: application/json
- Format: Array of UpdateStockRequest objects

UpdateStockRequest Object:
{
  "productId": Long (required),
  "quantity": int
}

Response:
- Status Code: 200 OK (If the request is successful)
- Content-Type: application/json
```

```json
[
  {
    "productId": 12345,
    "quantity": 10
  },
  {
    "productId": 54321,
    "quantity": 5
  }
]
```
#28 