### PR TITLE
[order-service] 주문 확정 API 추가

### DIFF
--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/ErrorCode.java
@@ -21,7 +21,6 @@ public enum ErrorCode {
 	MEMBER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "M_003", "이미 '%s'라는 이메일로 가입된 계정이 존재합니다."),
 	MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M_004", "멤버(id = %d)가 존재하지 않습니다."),
 
-
 	COUPON_EXPIRED_ERROR(HttpStatus.BAD_REQUEST, "CO_001", "유효하지 않은 쿠폰입니다."),
 	INVALID_COUPON_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "CO_002", "쿠폰의 유효기간이 잘못되었습니다."),
 	INVALID_COUPON_STRATEGY(HttpStatus.INTERNAL_SERVER_ERROR, "CO_003", "유효하지 않은 비율정책입니다."),
@@ -29,6 +28,9 @@ public enum ErrorCode {
 	COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "CO_005", "이미 발급받은 쿠폰(id = %d, 이름 = %s) 입니다."),
 	COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, "CO_006", "사용할 수 있는 쿠폰 id 중에 %s에 해당하는 쿠폰들이 없습니다."),
 
+	ORDER_NOT_EXIST(HttpStatus.NOT_FOUND, "O_001", "주문(id = %d)이 존재하지 않습니다."),
+	PENDING_ORDER_NOT_EXIST(HttpStatus.NOT_FOUND, "O_002", "주문이 존재하지 않거나, 처리할 수 없는 상태입니다."),
+	ORDER_COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, "O_003", "주문(id = %d)에 해당하는 쿠폰이 존재하지 않습니다."),
 
 	INVALID_MAINTENANCE_TIME(HttpStatus.INTERNAL_SERVER_ERROR, "B_001", "은행 점검기간이 유효하게 설정되지 않았습니다."),
 
@@ -37,7 +39,8 @@ public enum ErrorCode {
 	INVALID_PASSWORD_ERROR(HttpStatus.BAD_REQUEST, "CA_003", "잘못된 비밀번호 입니다."),
 
 	INVALID_PRICE_ERROR(HttpStatus.BAD_REQUEST, "P_001", "유효하지 않은 가격입니다."),
-	INVALID_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "P_002", "유효하지 않은 수량입니다.");
+	INVALID_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "P_002", "유효하지 않은 수량입니다."),
+	NOT_ENOUGH_STOCK(HttpStatus.BAD_REQUEST, "P_003", "재고가 부족합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/module-common/src/main/java/com/github/msafriends/modulecommon/exception/InvalidStateException.java
+++ b/module-common/src/main/java/com/github/msafriends/modulecommon/exception/InvalidStateException.java
@@ -5,7 +5,7 @@ public class InvalidStateException extends BusinessException {
         super(errorCode);
     }
 
-    public InvalidStateException(ErrorCode errorCode, String detail) {
-        super(errorCode, detail);
+    public InvalidStateException(ErrorCode errorCode, Object... args) {
+        super(errorCode, args);
     }
 }

--- a/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/client/MemberServiceClient.java
+++ b/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/client/MemberServiceClient.java
@@ -1,15 +1,16 @@
 package com.github.msafriends.serviceorder.moduleapi.client;
 
-import com.github.msafriends.serviceorder.modulecore.dto.response.coupon.OrderCouponResponse;
+import com.github.msafriends.serviceorder.modulecore.dto.request.coupon.MemberCouponUseRequest;
+import com.github.msafriends.serviceorder.modulecore.dto.response.ListResponse;
+import com.github.msafriends.serviceorder.modulecore.dto.response.coupon.MemberCouponResponse;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "member-service")
 public interface MemberServiceClient {
 
-    @GetMapping("/api/internal/v1/members/{memberId}/coupons")
-    List<OrderCouponResponse> getAvailableCouponsByMemberId(@PathVariable Long memberId);
+    @PostMapping("/api/internal/v1/members/{memberId}/coupons")
+    ListResponse<MemberCouponResponse> useCoupons(@PathVariable Long memberId, @RequestBody MemberCouponUseRequest request);
 }

--- a/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/client/ProductServiceClient.java
+++ b/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/client/ProductServiceClient.java
@@ -1,12 +1,14 @@
 package com.github.msafriends.serviceorder.moduleapi.client;
 
-import com.github.msafriends.serviceorder.modulecore.dto.response.order.ProductResponse;
+import com.github.msafriends.serviceorder.modulecore.dto.request.order.UpdateStockRequest;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @FeignClient(name = "product-service")
 public interface ProductServiceClient {
-    @GetMapping("/api/v1/products/{productId}")
-    ProductResponse getProduct(@PathVariable Long productId);
+    @PostMapping("/api/internal/v1/products/stocks")
+    void bulkUpdateProductStocks(@RequestBody List<UpdateStockRequest> requests);
 }

--- a/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/service/OrderService.java
+++ b/service-order/module-api/src/main/java/com/github/msafriends/serviceorder/moduleapi/service/OrderService.java
@@ -1,20 +1,26 @@
 package com.github.msafriends.serviceorder.moduleapi.service;
 
+import com.github.msafriends.modulecommon.exception.EntityNotFoundException;
+import com.github.msafriends.modulecommon.exception.ErrorCode;
+import com.github.msafriends.modulecommon.exception.InvalidStateException;
 import com.github.msafriends.serviceorder.moduleapi.client.MemberServiceClient;
-import com.github.msafriends.serviceorder.modulecore.repository.OrderRepository;
-import com.github.msafriends.serviceorder.modulecore.domain.coupon.OrderCoupon;
+import com.github.msafriends.serviceorder.moduleapi.client.ProductServiceClient;
 import com.github.msafriends.serviceorder.modulecore.domain.order.Order;
 import com.github.msafriends.serviceorder.modulecore.domain.order.OrderStatus;
+import com.github.msafriends.serviceorder.modulecore.dto.request.coupon.MemberCouponUseRequest;
 import com.github.msafriends.serviceorder.modulecore.dto.request.order.ConfirmOrderRequest;
 import com.github.msafriends.serviceorder.modulecore.dto.request.order.UpdateCartItemRequest;
-import com.github.msafriends.serviceorder.modulecore.dto.response.coupon.OrderCouponResponse;
+import com.github.msafriends.serviceorder.modulecore.dto.request.order.UpdateStockRequest;
+import com.github.msafriends.serviceorder.modulecore.dto.response.ListResponse;
+import com.github.msafriends.serviceorder.modulecore.dto.response.coupon.MemberCouponResponse;
 import com.github.msafriends.serviceorder.modulecore.dto.response.order.OrderPendingResponse;
 import com.github.msafriends.serviceorder.modulecore.dto.response.order.OrderResponse;
+import com.github.msafriends.serviceorder.modulecore.repository.OrderRepository;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,11 +29,12 @@ import java.util.Optional;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final MemberServiceClient memberServiceClient;
+    private final ProductServiceClient productServiceClient;
 
     public OrderResponse getOrder(Long orderId) {
         return orderRepository.findById(orderId)
                 .map(OrderResponse::from)
-                .orElseThrow(() -> new RuntimeException("Order not found"));
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ORDER_NOT_EXIST, orderId));
     }
 
     public List<OrderResponse> getOrderDetailsAwaitingAcceptance(Long memberId) {
@@ -54,26 +61,27 @@ public class OrderService {
         return orderRepository.save(pendingOrder).getId();
     }
 
+    @Transactional
     public void confirmOrder(Long memberId, ConfirmOrderRequest request) {
         Order order = orderRepository.findByMemberIdAndStatus(memberId, OrderStatus.PENDING)
-                .orElseThrow(() -> new RuntimeException("Order not found"));
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PENDING_ORDER_NOT_EXIST));
+
+        try {
+            productServiceClient.bulkUpdateProductStocks(UpdateStockRequest.from(order.getCartItems(), false));
+        } catch (FeignException ex) {
+            throw new InvalidStateException(ErrorCode.NOT_ENOUGH_STOCK);
+        }
+
+        try {
+            ListResponse<MemberCouponResponse> response = memberServiceClient.useCoupons(memberId, new MemberCouponUseRequest(request.getOrderCouponIds()));
+            order.addCoupons(MemberCouponResponse.from(response.getValues()));
+        } catch (FeignException ex) {
+            productServiceClient.bulkUpdateProductStocks(UpdateStockRequest.from(order.getCartItems(), true));
+            throw new InvalidStateException(ErrorCode.ORDER_COUPON_NOT_EXIST, order.getId());
+        }
+
         order.confirm(request);
-        applyCoupons(order, request.getOrderCouponIds());
         orderRepository.save(order);
-    }
-
-    private void applyCoupons(Order order, List<Long> orderCouponIds) {
-        List<OrderCouponResponse> availableCoupons = memberServiceClient.getAvailableCouponsByMemberId(order.getMemberId());
-        List<OrderCoupon> appliedCoupons = new ArrayList<>();
-
-        orderCouponIds.forEach(couponId -> {
-            OrderCouponResponse coupon = availableCoupons.stream()
-                    .filter(c -> c.getId().equals(couponId))
-                    .findFirst()
-                    .orElseThrow(() -> new RuntimeException("Coupon not found"));
-            appliedCoupons.add(OrderCouponResponse.toCoupon(order, coupon));
-        });
-        order.addCoupons(appliedCoupons);
     }
 
     @Transactional

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/domain/order/CartItem.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/domain/order/CartItem.java
@@ -1,7 +1,7 @@
 package com.github.msafriends.serviceorder.modulecore.domain.order;
 
 import com.github.msafriends.modulecommon.base.BaseTimeEntity;
-import com.github.msafriends.serviceorder.modulecore.domain.product.Product;
+import com.github.msafriends.serviceorder.modulecore.domain.product.OrderProduct;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,21 +26,21 @@ public class CartItem extends BaseTimeEntity {
     private Order order;
 
     @Embedded
-    private Product product;
+    private OrderProduct product;
 
     @Builder
-    public CartItem(Order order, Product product) {
+    public CartItem(Order order, OrderProduct product) {
         validateCartItem(order, product);
 
         this.order = order;
         this.product = product;
     }
 
-    private void validateCartItem(Order order, Product product) {
+    private void validateCartItem(Order order, OrderProduct product) {
         validateNotNull(order, product);
     }
 
-    private void validateNotNull(Order order, Product product) {
+    private void validateNotNull(Order order, OrderProduct product) {
         Assert.notNull(order, "order must not be null");
         Assert.notNull(product, "product must not be null");
     }

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/domain/product/OrderProduct.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/domain/product/OrderProduct.java
@@ -11,7 +11,7 @@ import org.springframework.util.Assert;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Product {
+public class OrderProduct {
 
     @Column(name = "product_id", nullable = false)
     private Long id;
@@ -26,7 +26,7 @@ public class Product {
     private int price;
 
     @Builder
-    public Product(Long id, String name, int quantity, int price) {
+    public OrderProduct(Long id, String name, int quantity, int price) {
         validateProduct(id, name, quantity, price);
 
         this.id = id;

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/coupon/MemberCouponUseRequest.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/coupon/MemberCouponUseRequest.java
@@ -1,0 +1,17 @@
+package com.github.msafriends.serviceorder.modulecore.dto.request.coupon;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberCouponUseRequest {
+    private List<Long> memberCouponIds;
+
+    public MemberCouponUseRequest(final List<Long> memberCouponIds) {
+        this.memberCouponIds = memberCouponIds;
+    }
+}

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/CartItemRequest.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/CartItemRequest.java
@@ -1,9 +1,14 @@
 package com.github.msafriends.serviceorder.modulecore.dto.request.order;
 
+import com.github.msafriends.serviceorder.modulecore.domain.order.CartItem;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
+import java.util.List;
+
+@Setter
 @Getter
 public class CartItemRequest {
     private final Long productId;
@@ -15,5 +20,18 @@ public class CartItemRequest {
     public CartItemRequest(Long productId, Integer quantity) {
         this.productId = productId;
         this.quantity = quantity;
+    }
+
+    public static CartItemRequest from(CartItem cartItem) {
+        return CartItemRequest.builder()
+                .productId(cartItem.getProduct().getId())
+                .quantity(cartItem.getProduct().getQuantity())
+                .build();
+    }
+
+    public static List<CartItemRequest> from(List<CartItem> cartItems) {
+        return cartItems.stream()
+                .map(CartItemRequest::from)
+                .toList();
     }
 }

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/UpdateCartItemRequest.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/UpdateCartItemRequest.java
@@ -2,7 +2,7 @@ package com.github.msafriends.serviceorder.modulecore.dto.request.order;
 
 import com.github.msafriends.serviceorder.modulecore.domain.order.CartItem;
 import com.github.msafriends.serviceorder.modulecore.domain.order.Order;
-import com.github.msafriends.serviceorder.modulecore.domain.product.Product;
+import com.github.msafriends.serviceorder.modulecore.domain.product.OrderProduct;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
@@ -31,8 +31,8 @@ public class UpdateCartItemRequest {
         this.price = price;
     }
 
-    public static Product toProduct(final UpdateCartItemRequest request) {
-        return Product.builder()
+    public static OrderProduct toProduct(final UpdateCartItemRequest request) {
+        return OrderProduct.builder()
                 .id(request.getProductId())
                 .name(request.getName())
                 .price(request.getPrice())

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/UpdateStockRequest.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/request/order/UpdateStockRequest.java
@@ -1,0 +1,36 @@
+package com.github.msafriends.serviceorder.modulecore.dto.request.order;
+
+import com.github.msafriends.serviceorder.modulecore.domain.order.CartItem;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateStockRequest {
+    private Long productId;
+
+    private int quantity;
+
+    @Builder
+    public UpdateStockRequest(Long productId, int quantity) {
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public static UpdateStockRequest from(CartItem cartItem, boolean decrease) {
+        return UpdateStockRequest.builder()
+                .productId(cartItem.getProduct().getId())
+                .quantity(cartItem.getProduct().getQuantity() * (decrease ? -1 : 1))
+                .build();
+    }
+
+    public static List<UpdateStockRequest> from(List<CartItem> cartItems, boolean decrease) {
+        return cartItems.stream()
+                .map(cartItem -> UpdateStockRequest.from(cartItem, decrease))
+                .toList();
+    }
+}

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/ListResponse.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/ListResponse.java
@@ -1,0 +1,19 @@
+package com.github.msafriends.serviceorder.modulecore.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ListResponse<T> {
+    private int valueCount;
+    private List<T> values;
+
+    public ListResponse(int valueCount, List<T> values) {
+        this.valueCount = valueCount;
+        this.values = values;
+    }
+}

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/coupon/MemberCouponResponse.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/coupon/MemberCouponResponse.java
@@ -1,0 +1,60 @@
+package com.github.msafriends.serviceorder.modulecore.dto.response.coupon;
+
+import com.github.msafriends.serviceorder.modulecore.domain.coupon.CouponDiscountType;
+import com.github.msafriends.serviceorder.modulecore.domain.coupon.OrderCoupon;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberCouponResponse {
+    private Long id;
+    private String name;
+    private Boolean hasUsed;
+    private CouponDiscountType discountType;
+    private int discountValue;
+    private LocalDateTime usedAt;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+
+    @Builder
+    private MemberCouponResponse(
+            Long id,
+            String name,
+            Boolean hasUsed,
+            CouponDiscountType discountType,
+            int discountValue,
+            LocalDateTime usedAt,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
+        this.id = id;
+        this.name = name;
+        this.hasUsed = hasUsed;
+        this.discountType = discountType;
+        this.discountValue = discountValue;
+        this.usedAt = usedAt;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    public static OrderCoupon from(MemberCouponResponse memberCouponResponse) {
+        return OrderCoupon.builder()
+                .couponId(memberCouponResponse.getId())
+                .name(memberCouponResponse.getName())
+                .discountType(memberCouponResponse.getDiscountType())
+                .discountValue(memberCouponResponse.getDiscountValue())
+                .build();
+    }
+
+    public static List<OrderCoupon> from(List<MemberCouponResponse> memberCouponResponses) {
+        return memberCouponResponses.stream()
+                .map(MemberCouponResponse::from)
+                .toList();
+    }
+}

--- a/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/order/ProductResponse.java
+++ b/service-order/module-core/src/main/java/com/github/msafriends/serviceorder/modulecore/dto/response/order/ProductResponse.java
@@ -1,6 +1,6 @@
 package com.github.msafriends.serviceorder.modulecore.dto.response.order;
 
-import com.github.msafriends.serviceorder.modulecore.domain.product.Product;
+import com.github.msafriends.serviceorder.modulecore.domain.product.OrderProduct;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,7 +18,7 @@ public class ProductResponse {
         this.price = price;
     }
 
-    public static ProductResponse from(final Product product) {
+    public static ProductResponse from(final OrderProduct product) {
         return ProductResponse.builder()
                 .id(product.getId())
                 .quantity(product.getQuantity())
@@ -26,8 +26,8 @@ public class ProductResponse {
                 .build();
     }
 
-    public static Product toProduct(final ProductResponse productResponse) {
-        return Product.builder()
+    public static OrderProduct toProduct(final ProductResponse productResponse) {
+        return OrderProduct.builder()
                 .id(productResponse.getId())
                 .quantity(productResponse.getQuantity())
                 .price(productResponse.getPrice())

--- a/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/CartItemFixture.java
+++ b/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/CartItemFixture.java
@@ -2,12 +2,12 @@ package com.github.msafriends.serviceorder.modulecore.fixture;
 
 import com.github.msafriends.serviceorder.modulecore.domain.order.Order;
 import com.github.msafriends.serviceorder.modulecore.domain.order.CartItem;
-import com.github.msafriends.serviceorder.modulecore.domain.product.Product;
+import com.github.msafriends.serviceorder.modulecore.domain.product.OrderProduct;
 import com.github.msafriends.serviceorder.modulecore.dto.request.order.CartItemRequest;
 import com.github.msafriends.serviceorder.modulecore.dto.request.order.UpdateCartItemRequest;
 
 public class CartItemFixture {
-    private static final Product DEFAULT_PRODUCT = ProductFixture.createDefaultProduct();
+    private static final OrderProduct DEFAULT_PRODUCT = ProductFixture.createDefaultProduct();
 
     private static CartItem.CartItemBuilder createDefaultCartItemBuilder(Order order) {
         return CartItem.builder()

--- a/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/MemberCouponFixture.java
+++ b/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/MemberCouponFixture.java
@@ -1,0 +1,18 @@
+package com.github.msafriends.serviceorder.modulecore.fixture;
+
+import com.github.msafriends.serviceorder.modulecore.dto.request.coupon.MemberCouponUseRequest;
+
+import java.util.List;
+
+public class MemberCouponFixture {
+
+    private static final List<Long> MEMBER_COUPON_IDS = List.of(1L, 2L, 3L);
+
+    public static MemberCouponUseRequest createDefaultMemberCouponUseRequest() {
+        return createMemberCouponUseRequest(MEMBER_COUPON_IDS);
+    }
+
+    public static MemberCouponUseRequest createMemberCouponUseRequest(List<Long> memberCouponIds) {
+        return new MemberCouponUseRequest(memberCouponIds);
+    }
+}

--- a/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/ProductFixture.java
+++ b/service-order/module-core/src/testFixtures/java/com/github/msafriends/serviceorder/modulecore/fixture/ProductFixture.java
@@ -1,6 +1,6 @@
 package com.github.msafriends.serviceorder.modulecore.fixture;
 
-import com.github.msafriends.serviceorder.modulecore.domain.product.Product;
+import com.github.msafriends.serviceorder.modulecore.domain.product.OrderProduct;
 import com.github.msafriends.serviceorder.modulecore.dto.response.order.ProductResponse;
 
 public class ProductFixture {
@@ -10,26 +10,26 @@ public class ProductFixture {
     public static final int DEFAULT_QUANTITY = 1;
     public static final int DEFAULT_PRICE = 1000;
 
-    private static Product.ProductBuilder createDefaultProductBuilder() {
-        return Product.builder()
+    private static OrderProduct.OrderProductBuilder createDefaultProductBuilder() {
+        return OrderProduct.builder()
                 .id(DEFAULT_PRODUCT_ID)
                 .name(DEFAULT_PRODUCT_NAME)
                 .quantity(DEFAULT_QUANTITY)
                 .price(DEFAULT_PRICE);
     }
 
-    public static Product createDefaultProduct() {
+    public static OrderProduct createDefaultProduct() {
         return createDefaultProductBuilder()
                 .build();
     }
 
-    public static Product createProductWithPrice(int price) {
+    public static OrderProduct createProductWithPrice(int price) {
         return createDefaultProductBuilder()
                 .price(price)
                 .build();
     }
 
-    public static Product createProductWithQuantity(int quantity) {
+    public static OrderProduct createProductWithQuantity(int quantity) {
         return createDefaultProductBuilder()
                 .quantity(quantity)
                 .build();


### PR DESCRIPTION
## What is this PR do?
주문 확정 API 엔드포인트를 추가했습니다.

## Changes
- [x] : 주문을 확정하는 API를 추가함
- [x] : 혼동을 피하기 위해 더 명확한 이름으로 클래스명을 변경함

## Tests
- [x] : 주문 서비스의 주문 확정 메서드가 단위 테스트에서 정상적으로 동작함을 확인함

## References
- #33 